### PR TITLE
fix: コピーボタンが失敗する問題を修正

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,9 +1,9 @@
 {
   "manifest_version": 3,
   "name": "Notion to Image",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Notionで選択したテキストをGemini APIで画像生成する",
-  "permissions": ["storage", "activeTab", "scripting"],
+  "permissions": ["storage", "activeTab", "scripting", "clipboardWrite"],
   "host_permissions": [
     "https://www.notion.so/*",
     "https://generativelanguage.googleapis.com/*"


### PR DESCRIPTION
## 原因

`manifest.json` に `clipboardWrite` 権限が不足していたため、`navigator.clipboard.write()` が失敗していた。

## 変更内容

- `manifest.json`: `permissions` に `"clipboardWrite"` を追加
- バージョンを `1.0.0` → `1.0.1` に更新